### PR TITLE
Link DOIs to preferred resolver

### DIFF
--- a/aprl/publications.html
+++ b/aprl/publications.html
@@ -173,7 +173,7 @@ K.&nbsp;M. Shakya, S.&nbsp;Liu, S.&nbsp;Takahama, L.&nbsp;M. Russell, F.&nbsp;N.
   1,2,4-Trimethylbenzene, and d-Limonene.
  <em>Aerosol Science &amp; Technology</em>, accepted, 2013.
 [&nbsp;<a href="peer-reviewed_bib.html#Shakya2013">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1080/02786826.2013.772950">DOI</a>&nbsp;|
+<a href="https://doi.org/10.1080/02786826.2013.772950">DOI</a>&nbsp;|
 <a href="files/Shakya2013.pdf">pdf</a>&nbsp;]
 
 
@@ -193,7 +193,7 @@ J.&nbsp;Zheng, R.&nbsp;Zhang, J.&nbsp;P. Garz&oacute;n, M.&nbsp;E. Huertas, M.&n
   Cal-Mex 2010 Air Quality Study.
  <em>Atmospheric Environment</em>, in press, 2012.
 [&nbsp;<a href="peer-reviewed_bib.html#Zheng2012">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1016/j.atmosenv.2012.09.041">DOI</a>&nbsp;|
+<a href="https://doi.org/10.1016/j.atmosenv.2012.09.041">DOI</a>&nbsp;|
 <a href="files/Zheng2012.pdf">pdf</a>&nbsp;]
 
 
@@ -211,7 +211,7 @@ S.&nbsp;Takahama, A.&nbsp;Johnson, and L.&nbsp;M. Russell.
   organic aerosol infrared absorbance spectra.
  <em>Aerosol Science and Technology</em>, 47:3, 2013.
 [&nbsp;<a href="peer-reviewed_bib.html#Takahama2013">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1080/02786826.2012.752065">DOI</a>&nbsp;|
+<a href="https://doi.org/10.1080/02786826.2012.752065">DOI</a>&nbsp;|
 <a href="files/Takahama2013.pdf">pdf</a>&nbsp;]
 
 
@@ -230,7 +230,7 @@ S.&nbsp;Takahama, A.&nbsp;Johnson, J.&nbsp;Guzman Morales, L.M. Russell, R.&nbsp
   Southern California sources during the CalMex campaign.
  <em>Atmospheric Environment</em>, in press, 2012.
 [&nbsp;<a href="peer-reviewed_bib.html#Takahama2012">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1016/j.atmosenv.2012.07.057">DOI</a>&nbsp;|
+<a href="https://doi.org/10.1016/j.atmosenv.2012.07.057">DOI</a>&nbsp;|
 <a href="files/Takahama2012.pdf">pdf</a>&nbsp;]
 
 
@@ -249,7 +249,7 @@ S.&nbsp;Takahama, R.&nbsp;E. Schwartz, L.&nbsp;M. Russell, A.&nbsp;M. Macdonald,
   non-burning forest emissions at a high-elevation mountain site.
  <em>Atmospheric Chemistry and Physics</em>, 11(13):6367-6386, 2011.
 [&nbsp;<a href="peer-reviewed_bib.html#Takahama2011a">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.5194/acp-11-6367-2011">DOI</a>&nbsp;|
+<a href="https://doi.org/10.5194/acp-11-6367-2011">DOI</a>&nbsp;|
 <a href="files/Takahama2011a.pdf">pdf</a>&nbsp;]
 
 
@@ -268,7 +268,7 @@ S.&nbsp;Takahama and L.&nbsp;M. Russell.
  <em>Journal of Geophysical Research-Atmospheres</em>, 116:D02203,
   January 2011.
 [&nbsp;<a href="peer-reviewed_bib.html#Takahama2011">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1029/2010JD014842">DOI</a>&nbsp;|
+<a href="https://doi.org/10.1029/2010JD014842">DOI</a>&nbsp;|
 <a href="files/Takahama2011.pdf">pdf</a>&nbsp;]
 
 
@@ -291,7 +291,7 @@ W.&nbsp;Richard Leaitch, Anne&nbsp;Marie Macdonald, Peter&nbsp;C. Brickell, John
   forests.
  <em>Atmospheric Environment</em>, 45(37):6696 - 6704, 2011.
 [&nbsp;<a href="peer-reviewed_bib.html#Leaitch2011">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1016/j.atmosenv.2011.08.047">DOI</a>&nbsp;|
+<a href="https://doi.org/10.1016/j.atmosenv.2011.08.047">DOI</a>&nbsp;|
 <a href="files/Leaitch2011.pdf">pdf</a>&nbsp;]
 
 
@@ -311,7 +311,7 @@ S.&nbsp;Takahama, S.&nbsp;Liu, and L.&nbsp;M. Russell.
  <em>Journal of Geophysical Research-Atmospheres</em>, 115:D01202,
   January 2010.
 [&nbsp;<a href="peer-reviewed_bib.html#Takahama2010">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1029/2009JD012622">DOI</a>&nbsp;|
+<a href="https://doi.org/10.1029/2009JD012622">DOI</a>&nbsp;|
 <a href="files/Takahama2010.pdf">pdf</a>&nbsp;]
 
 
@@ -332,7 +332,7 @@ W.&nbsp;R. Leaitch, A.&nbsp;M. Macdonald, K.&nbsp;G. Anlauf, P.&nbsp;S.&nbsp;K. 
   during INTEX-B 2006 near Whistler, BC.
  <em>Atmospheric Chemistry and Physics</em>, 9(11):3523-3546, 2009.
 [&nbsp;<a href="peer-reviewed_bib.html#Leaitch2009">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.5194/acp-9-3523-2009">DOI</a>&nbsp;|
+<a href="https://doi.org/10.5194/acp-9-3523-2009">DOI</a>&nbsp;|
 <a href="files/Leaitch2009.pdf">pdf</a>&nbsp;]
 
 
@@ -353,7 +353,7 @@ L.&nbsp;M. Russell, S.&nbsp;Takahama, S.&nbsp;Liu, L.&nbsp;N. Hawkins, D.&nbsp;S
  <em>Journal of Geophysical Research-Atmospheres</em>, 114:D00F05,
   April 2009.
 [&nbsp;<a href="peer-reviewed_bib.html#Russell2009">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1029/2008JD011275">DOI</a>&nbsp;|
+<a href="https://doi.org/10.1029/2008JD011275">DOI</a>&nbsp;|
 <a href="files/Russell2009.pdf">pdf</a>&nbsp;|
 <a href="files/Russell2009">supplemental</a>&nbsp;]
 
@@ -372,7 +372,7 @@ S.&nbsp;Liu, S.&nbsp;Takahama, L.&nbsp;M. Russell, S.&nbsp;Gilardoni, and D.&nbs
   submicron organic particles in MILAGRO 2006 campaign.
  <em>Atmospheric Chemistry and Physics</em>, 9(18):6849-6863, 2009.
 [&nbsp;<a href="peer-reviewed_bib.html#Liu2009">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.5194/acp-9-6849-2009">DOI</a>&nbsp;|
+<a href="https://doi.org/10.5194/acp-9-6849-2009">DOI</a>&nbsp;|
 <a href="files/Liu2009.pdf">pdf</a>&nbsp;]
 
 
@@ -391,7 +391,7 @@ S.&nbsp;Gilardoni, S.&nbsp;Liu, S.&nbsp;Takahama, L.&nbsp;M. Russell, J.&nbsp;D.
   three platforms.
  <em>Atmospheric Chemistry and Physics</em>, 9(15):5417-5432, 2009.
 [&nbsp;<a href="peer-reviewed_bib.html#Gilardoni2009">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.5194/acp-9-5417-2009">DOI</a>&nbsp;|
+<a href="https://doi.org/10.5194/acp-9-5417-2009">DOI</a>&nbsp;|
 <a href="files/Gilardoni2009.pdf">pdf</a>&nbsp;]
 
 
@@ -410,7 +410,7 @@ D.&nbsp;A. Day, S.&nbsp;Takahama, S.&nbsp;Gilardoni, and L.&nbsp;M. Russell.
   2006.
  <em>Atmospheric Chemistry and Physics</em>, 9(15):5433-5446, 2009.
 [&nbsp;<a href="peer-reviewed_bib.html#Day2009">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.5194/acp-9-5433-2009">DOI</a>&nbsp;|
+<a href="https://doi.org/10.5194/acp-9-5433-2009">DOI</a>&nbsp;|
 <a href="files/Day2009.pdf">pdf</a>&nbsp;]
 
 
@@ -429,7 +429,7 @@ S.&nbsp;Takahama, S.&nbsp;Gilardoni, and L.&nbsp;M. Russell.
  <em>Journal of Geophysical Research-Atmospheres</em>, 113:D22202,
   November 2008.
 [&nbsp;<a href="peer-reviewed_bib.html#Takahama2008">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1029/2008JD009810">DOI</a>&nbsp;|
+<a href="https://doi.org/10.1029/2008JD009810">DOI</a>&nbsp;|
 <a href="files/Takahama2008.pdf">pdf</a>&nbsp;]
 
 
@@ -447,7 +447,7 @@ S.&nbsp;Takahama, S.&nbsp;Gilardoni, L.&nbsp;M. Russell, and A.&nbsp;L.&nbsp;D. 
   atmospheric particles by scanning transmission X-ray microscopy analysis.
  <em>Atmospheric Environment</em>, 41(40):9435-9451, December 2007.
 [&nbsp;<a href="peer-reviewed_bib.html#Takahama2007a">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1016/j.atmosenv.2007.08.051">DOI</a>&nbsp;|
+<a href="https://doi.org/10.1016/j.atmosenv.2007.08.051">DOI</a>&nbsp;|
 <a href="files/Takahama2007a.pdf">pdf</a>&nbsp;]
 
 
@@ -466,7 +466,7 @@ Satoshi Takahama, Ravi&nbsp;K. Pathak, and Spyros&nbsp;N. Pandis.
  <em>Environmental Science &amp; Technology</em>, 41(7):2289-2295, April
   2007.
 [&nbsp;<a href="peer-reviewed_bib.html#Takahama2007">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1021/es0619915">DOI</a>&nbsp;|
+<a href="https://doi.org/10.1021/es0619915">DOI</a>&nbsp;|
 <a href="files/Takahama2007.pdf">pdf</a>&nbsp;]
 
 
@@ -486,7 +486,7 @@ S.&nbsp;Takahama, C.&nbsp;I. Davidson, and S.&nbsp;N. Pandis.
  <em>Environmental Science &amp; Technology</em>, 40(7):2191-2199, April
   2006.
 [&nbsp;<a href="peer-reviewed_bib.html#Takahama2006">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1021/es050856+">DOI</a>&nbsp;|
+<a href="https://doi.org/10.1021/es050856+">DOI</a>&nbsp;|
 <a href="files/Takahama2006.pdf">pdf</a>&nbsp;]
 
 
@@ -506,7 +506,7 @@ Andrew&nbsp;P. Grieshop, Eric&nbsp;M. Lipsky, Natalie&nbsp;J. Pekney, Satoshi Ta
  <em>Atmospheric Environment</em>, 40:Amer Assoc Aerosol Res; US EPA,
   2006.
 [&nbsp;<a href="peer-reviewed_bib.html#Grieshop2006">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1016/j.atmosenv.2006.03.064">DOI</a>&nbsp;|
+<a href="https://doi.org/10.1016/j.atmosenv.2006.03.064">DOI</a>&nbsp;|
 <a href="files/Grieshop2006.pdf">pdf</a>&nbsp;]
 
 
@@ -526,7 +526,7 @@ D.&nbsp;V. Vayenas, S.&nbsp;Takahama, C.&nbsp;I. Davidson, and S.&nbsp;N. Pandis
  <em>Journal of Geophysical Research-Atmospheres</em>, 110(D7):D07S14,
   March 2005.
 [&nbsp;<a href="peer-reviewed_bib.html#Vayenas2005">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1029/2004JD005038">DOI</a>&nbsp;|
+<a href="https://doi.org/10.1029/2004JD005038">DOI</a>&nbsp;|
 <a href="files/Vayenas2005.pdf">pdf</a>&nbsp;]
 
 
@@ -545,7 +545,7 @@ A.&nbsp;Khlystov, C.&nbsp;O. Stanier, S.&nbsp;Takahama, and S.&nbsp;N. Pandis.
  <em>Journal of Geophysical Research-Atmospheres</em>, 110(D7):D07S10,
   March 2005.
 [&nbsp;<a href="peer-reviewed_bib.html#Khlystov2005">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1029/2004JD004651">DOI</a>&nbsp;|
+<a href="https://doi.org/10.1029/2004JD004651">DOI</a>&nbsp;|
 <a href="files/Khlystov2005.pdf">pdf</a>&nbsp;]
 
 
@@ -564,7 +564,7 @@ A.&nbsp;E. Wittig, S.&nbsp;Takahama, A.&nbsp;Y. Khlystov, S.&nbsp;N. Pandis, S.&
   Pittsburgh air quality study.
  <em>Atmospheric Environment</em>, 38(20):3201-3213, June 2004.
 [&nbsp;<a href="peer-reviewed_bib.html#Wittig2004">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1016/S1352-2310(04)00190-6">DOI</a>&nbsp;|
+<a href="https://doi.org/10.1016/S1352-2310(04)00190-6">DOI</a>&nbsp;|
 <a href="files/Wittig2004.pdf">pdf</a>&nbsp;]
 
 
@@ -583,7 +583,7 @@ S.&nbsp;Takahama, A.&nbsp;E. Wittig, D.&nbsp;V. Vayenas, C.&nbsp;I. Davidson, an
  <em>Journal of Geophysical Research-Atmospheres</em>, 109(D16):D16S06,
   July 2004.
 [&nbsp;<a href="peer-reviewed_bib.html#Takahama2004">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1029/2003JD004149">DOI</a>&nbsp;|
+<a href="https://doi.org/10.1029/2003JD004149">DOI</a>&nbsp;|
 <a href="files/Takahama2004.pdf">pdf</a>&nbsp;]
 
 
@@ -603,7 +603,7 @@ W.&nbsp;K. Modey, D.&nbsp;J. Eatough, R.&nbsp;R. Anderson, D.&nbsp;V. Martello, 
   study.
  <em>Atmospheric Environment</em>, 38(20):3165-3178, June 2004.
 [&nbsp;<a href="peer-reviewed_bib.html#Modey2004">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1016/S1352-2310(04)00193-1">DOI</a>&nbsp;|
+<a href="https://doi.org/10.1016/S1352-2310(04)00193-1">DOI</a>&nbsp;|
 <a href="files/Modey2004.pdf">pdf</a>&nbsp;]
 
 
@@ -622,7 +622,7 @@ J.&nbsp;C. Cabada, S.&nbsp;Rees, S.&nbsp;Takahama, A.&nbsp;Khlystov, S.&nbsp;N. 
   fine particulate matter at the Pittsburgh supersite.
  <em>Atmospheric Environment</em>, 38(20):3127-3141, June 2004.
 [&nbsp;<a href="peer-reviewed_bib.html#Cabada2004">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1016/j.atmosenv.2004.03.004">DOI</a>&nbsp;|
+<a href="https://doi.org/10.1016/j.atmosenv.2004.03.004">DOI</a>&nbsp;|
 <a href="files/Cabada2004.pdf">pdf</a>&nbsp;]
 
 

--- a/resources/programming/files/preamble_biblatex.tex
+++ b/resources/programming/files/preamble_biblatex.tex
@@ -33,7 +33,7 @@
         eprint=false
         }
 \newbibmacro{string+doi}[1]{%
-  \iffieldundef{doi}{#1}{\href{http://dx.doi.org/\thefield{doi}}{#1}}}
+  \iffieldundef{doi}{#1}{\href{https://doi.org/\thefield{doi}}{#1}}}
 \DeclareFieldFormat{doi}{\usebibmacro{string+doi}{doi:#1}}
 \AtEveryBibitem{% Clean up the bibtex rather than editing it
  \clearlist{language}

--- a/resources/programming/latex.html
+++ b/resources/programming/latex.html
@@ -818,7 +818,7 @@ Create doi links in bibliography:
 
 <pre class="src src-latex"><span style="font-weight: bold;">\ExecuteBibliographyOptions</span>{<span style="font-weight: bold; text-decoration: underline;">url=false,eprint=false</span>}
 \newbibmacro{string+doi}[1]{<span style="font-weight: bold; font-style: italic;">%</span>
-  \iffieldundef{doi}{#1}{\href{http://dx.doi.org/\thefield{doi}}{#1}}}
+  \iffieldundef{doi}{#1}{\href{https://doi.org/\thefield{doi}}{#1}}}
 \DeclareFieldFormat{doi}{\usebibmacro{string+doi}{doi:#1}}
 </pre>
 </div>


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). This PR implements that recommendation by updating static DOI links, as well as code that generates new ones.

Cheers!